### PR TITLE
increase logging in webhook-deliver to debug staging issue

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,9 @@ const defaultEnv = process.env
 class EnvToConfig {
   static eventTarget(env) {
     const envVar = env.EVENT_TARGET
-    if (envVar) { return new URL(envVar) }
+    if (envVar) {
+      return new URL(envVar)
+    }
   }
 
   static eventTargetCredentialsSecretName(env) {
@@ -34,10 +36,13 @@ const envToEventTargetConfig = async (
   eventTargetCredentialsSecretName = EnvToConfig.eventTargetCredentialsSecretName(env),
   parameters = defaultParameters
 ) => {
+  console.debug('envToEventTargetConfig called with', { eventTargetCredentialsSecretName })
   // if eventTargetCredentialsSecretName is set, it takes priority to determine final eventTarget string
   if (eventTargetCredentialsSecretName) {
     const eventTargetString = await parameters.readSecret({ name: eventTargetCredentialsSecretName })
+    console.debug(`did readSecret of eventTargetCredentialsSecretName=${eventTargetCredentialsSecretName}. typeof=${typeof eventTargetString}`)
     if (eventTargetString) {
+      console.debug('setting eventTarget to URL from dereferenced eventTargetCredentialsSecretName')
       eventTarget = new URL(eventTargetString)
     }
   }
@@ -47,9 +52,7 @@ const envToEventTargetConfig = async (
   }
 }
 
-const {
-  CONCURRENCY: rawConcurrency
-} = process.env
+const { CONCURRENCY: rawConcurrency } = process.env
 
 const concurrency = parseInt(rawConcurrency)
 

--- a/src/lib/webhook-deliver.js
+++ b/src/lib/webhook-deliver.js
@@ -21,9 +21,9 @@ function createWebhookDeliver(fetch) {
     })
     logger.debug(`delivering event via webhook type=${event.type}`)
     const response = await fetch(request)
-    logger.debug(`webhook delivery response status=${response.status}`)
+    logger.info(`webhook delivery response status=${response.status}`)
     // expect 2xx response status
-    assert.ok(response.status >= 200 && response.status < 300)
+    assert.ok(response.status >= 200 && response.status < 300, `expected 2xx response status code, but got ${response.status}`)
   }
 }
 


### PR DESCRIPTION
Motivation
* debug last pr toward https://github.com/elastic-ipfs/event-delivery-lambda/issues/6
* I think the lambda should in staging should be using the SSM parameter value for `config.eventTarget`. But I got an error. To debug lets turn up the logging